### PR TITLE
Depend on `color` crate rather than `peniko` crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,9 @@ path = "src/lib.rs"
 [dependencies]
 regex = "1.9.1"
 lazy_static = "1.4.0"
+color = "0.3.2"
+
+[dev-dependencies]
 peniko = "0.4.0"
 
 

--- a/README.md
+++ b/README.md
@@ -127,19 +127,19 @@ fn main() {
 }
 ```
 
-## Peniko Integration
+## `color` crate integration
 
 ```rust
 use bigcolor::{BigColor, conversion};
-use peniko::Color as PenikoColor;
+use color::AlphaColor;
 
 fn main() {
     // Convert from BigColor to peniko::Color
     let big_color = BigColor::new("#1a6ef5");
     let peniko_color = conversion::to_peniko_color(&big_color);
     
-    // Convert from peniko::Color to BigColor
-    let peniko_red = PenikoColor::from_rgb8(255, 0, 0);
+    // Convert from color::AlphaColor<Srgb> to BigColor
+    let peniko_red = AlphaColor::from_rgb8(255, 0, 0);
     let big_red = conversion::from_peniko_color(&peniko_red);
     
     println!("Original: {}", big_color.to_hex_string(false));

--- a/src/conversion.rs
+++ b/src/conversion.rs
@@ -1,28 +1,28 @@
 use crate::BigColor;
-use peniko::Color;
+use color::{AlphaColor, Srgb};
 
 /// Converts a BigColor to a peniko::Color
-/// 
+///
 /// This allows interoperability with the peniko color library and its
 /// ecosystem, which is useful for graphics applications.
-pub fn to_peniko_color(color: &BigColor) -> Color {
+pub fn to_peniko_color(color: &BigColor) -> AlphaColor<Srgb> {
     let rgb = color.to_rgb();
-    Color::from_rgba8(rgb.r, rgb.g, rgb.b, (rgb.a * 255.0) as u8)
+    AlphaColor::from_rgba8(rgb.r, rgb.g, rgb.b, (rgb.a * 255.0) as u8)
 }
 
 /// Converts a peniko::Color to a BigColor
-/// 
+///
 /// This allows importing colors from the peniko ecosystem into BigColor
 /// for advanced color manipulation.
-pub fn from_peniko_color(color: &Color) -> BigColor {
+pub fn from_peniko_color(color: &AlphaColor<Srgb>) -> BigColor {
     let rgba = color.to_rgba8();
     BigColor::from_rgb(rgba.r, rgba.g, rgba.b, rgba.a as f32 / 255.0)
-} 
+}
 
 /// Converts a string to a peniko::Color
-/// 
+///
 /// This allows importing colors from the peniko ecosystem into BigColor
 /// for advanced color manipulation.
-pub fn get_peniko_color(color: &str) -> Color {
+pub fn get_peniko_color(color: &str) -> AlphaColor<Srgb> {
     to_peniko_color(&BigColor::new(color))
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@ use std::fmt;
 use color_space::*;
 use parse::*;
 use crate::accessibility::{get_contrast_color as get_contrast_color_impl, get_contrast_ratio as get_contrast_ratio_impl};
-pub use peniko;
+pub use color;
 
 /// BigColor struct represents a color with various formats
 /// Using OKLCH as the foundation


### PR DESCRIPTION
`peniko::Color` is a re-export of `AlphaColor<Srgb>` from the [color](https://docs.rs/color) crate. So it makes sense to depend on that rather than whole of `peniko`.